### PR TITLE
set admin in group panel

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -792,3 +792,19 @@ export function resumeProgress(progress: number, cid: string): ResumeProgress {
         cid
     };
 }
+
+export const SET_GROUP_ADMIN = 'SET_GROUP_ADMIN';
+export type SET_GROUP_ADMIN = typeof SET_GROUP_ADMIN;
+export interface SetGroupAdmin {
+    type: SET_GROUP_ADMIN;
+    data: {
+        group: string;
+        who: string[];
+    };
+}
+export function setGroupAdmin(data: SetGroupAdmin['data']) {
+    return {
+        type: SET_GROUP_ADMIN,
+        data,
+    };
+}

--- a/src/components/Group/index.tsx
+++ b/src/components/Group/index.tsx
@@ -1,5 +1,7 @@
-import React, { FC, memo } from 'react';
+import Button from '@material-ui/core/Button';
+import React, {FC, memo, useState} from 'react';
 
+import Checkbox from '@material-ui/core/Checkbox';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -18,21 +20,44 @@ import useStyles from '../../styles/group';
 import { titleConverter } from '../../utils/titleConverter';
 
 const heads = ['成员姓名', '性别', '电话号码', '邮箱', '加入时间', '组长？', '管理员？'];
-const memberDataConverter = ({ username, gender, phone, mail, joinTime, isCaptain, isAdmin }: User) => [
-    username,
-    GENDERS[gender],
-    phone || '未知',
-    mail || '未知',
-    titleConverter(joinTime),
-    isCaptain ? '是' : '否',
-    isAdmin ? '是' : '否',
-];
 
-const Group: FC<Props> = memo(({ groupInfo }) => {
+type SelectHandler = (name: string) => (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
+const memberDataConverter = (handleSelect: SelectHandler, admin: object, disabled: boolean) =>
+    ({ username, gender, phone, mail, joinTime, isCaptain }: User) => [
+        username,
+        GENDERS[gender],
+        phone || '未知',
+        mail || '未知',
+        titleConverter(joinTime),
+        isCaptain ? '是' : '否',
+        (<Checkbox
+            checked={admin[username]}
+            onChange={handleSelect(username)}
+            disabled={disabled}
+            color='primary'
+        />)
+    ];
+
+const Group: FC<Props> = memo(({ groupInfo, canSetAdmin, submitAdmin, group}) => {
     const classes = useStyles();
+
     if (!groupInfo) {
         return null;
     }
+
+    // { user1: true, user2: false ...}
+    const [admin, setAdmin] = useState(Object.fromEntries(
+        groupInfo.map((member) => [member.username, member.isAdmin]),
+    ));
+
+    const handleSelect = (name: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+        setAdmin({...admin, [name]: event.target.checked});
+    };
+
+    const submitChange = () => {
+        submitAdmin({group, who: Object.keys(admin).filter((i) => admin[i])});
+    };
+
     return (
         <div className={classes.infoContainer}>
             <Paper className={classes.paper}>
@@ -46,20 +71,25 @@ const Group: FC<Props> = memo(({ groupInfo }) => {
                         <TableHead>
                             <TableRow>
                                 {heads.map((head, index) =>
-                                    <TableCell key={index} classes={{ root: classes.tableCell }}>{head}</TableCell>,
+                                    <TableCell key={index} classes={{root: classes.tableCell}}>{head}</TableCell>,
                                 )}
                             </TableRow>
                         </TableHead>
                         <TableBody>
-                            {groupInfo.map(memberDataConverter).map((member, index) => (
-                                <TableRow key={index}>
-                                    {member.map((item, idx) =>
-                                        <TableCell classes={{ root: classes.tableCell }} key={idx}>{item}</TableCell>,
-                                    )}
-                                </TableRow>
-                            ))}
+                            {groupInfo
+                                .map(memberDataConverter(handleSelect, admin, !canSetAdmin))
+                                .map((member, index) => (
+                                    <TableRow key={index}>
+                                        {member.map((item, idx) =>
+                                            <TableCell classes={{root: classes.tableCell}} key={idx}>{item}</TableCell>,
+                                        )}
+                                    </TableRow>
+                                ))}
                         </TableBody>
                     </Table>
+                </div>
+                <div>
+                    <Button size='large' onClick={submitChange} color='primary'>修改</Button>
                 </div>
             </Paper>
         </div>

--- a/src/containers/Group/index.ts
+++ b/src/containers/Group/index.ts
@@ -1,17 +1,20 @@
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
+import {connect} from 'react-redux';
+import {bindActionCreators, Dispatch} from 'redux';
 
-import { enqueueSnackbar } from '../../actions';
-import { StoreState } from '../../reducers';
+import {enqueueSnackbar, setGroupAdmin} from '../../actions';
+import {StoreState} from '../../reducers';
 
 import Group from '../../components/Group';
 
-const mapStateToProps = ({ user: { groupInfo } }: StoreState) => ({
+const mapStateToProps = ({ user: { groupInfo, info: { isAdmin, isCaptain, group } } }: StoreState) => ({
     groupInfo,
+    canSetAdmin: isCaptain || isAdmin,
+    group,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
     enqueueSnackbar,
+    submitAdmin: setGroupAdmin,
 }, dispatch);
 
 type StateProps = ReturnType<typeof mapStateToProps>;

--- a/src/epics/user/index.ts
+++ b/src/epics/user/index.ts
@@ -1,6 +1,7 @@
 import { getGroupEpic } from './getGroup';
 import { getInfoEpic } from './getInfo';
 import { getQRCodeEpic, loginEpic, scanQRCodeEpic } from './login';
+import { setGroupAdminEpic} from './setAdmin';
 import { setInfoEpic } from './setInfo';
 
-export default [getQRCodeEpic, scanQRCodeEpic, loginEpic, getInfoEpic, getGroupEpic, setInfoEpic];
+export default [getQRCodeEpic, scanQRCodeEpic, loginEpic, getInfoEpic, getGroupEpic, setInfoEpic, setGroupAdminEpic];

--- a/src/epics/user/setAdmin.ts
+++ b/src/epics/user/setAdmin.ts
@@ -1,0 +1,36 @@
+import { ofType } from 'redux-observable';
+import { of } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import { catchError, mergeMap, startWith } from 'rxjs/operators';
+
+import { enqueueSnackbar, SET_GROUP_ADMIN, SetGroupAdmin, toggleProgress } from '../../actions';
+
+import { API } from '../../config/consts';
+
+import { checkToken, customError, Epic, errHandler } from '../';
+
+export const setGroupAdminEpic: Epic<SetGroupAdmin> = (action$) =>
+    action$.pipe(
+        ofType(SET_GROUP_ADMIN),
+        mergeMap((action) => {
+            const token = checkToken();
+            const { data } = action;
+            return ajax.put(`${API}/user/group/admin`, JSON.stringify(data), {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            }).pipe(
+                mergeMap(({ response: res }) => {
+                    if (res.type === 'success') {
+                        return of(
+                            toggleProgress(),
+                            enqueueSnackbar('已成功修改管理员！', { variant: 'success' }),
+                        );
+                    }
+                    throw customError(res);
+                }),
+                startWith(toggleProgress(true)),
+                catchError((err) => errHandler(err)),
+            );
+        }),
+        catchError((err) => errHandler(err)),
+    );

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -38,7 +38,10 @@ const Dashboard: FC<Props> = memo(({ data, setViewing, viewing }) => {
                     <div className={classes.block}>
                         <AddOne shouldClear={shouldClear} />
                     </div>
-                    {!!data.length && data.map((recruitment) => (
+                    {!!data.length && data.slice().reverse().map((recruitment) => (
+                        // using slice() to create a shallow copy in case the
+                        // switching between router case problem
+                        // maybe it's better to change the order in backend :(
                         <div key={recruitment._id} className={classes.block}>
                             <Chart
                                 data={recruitment}


### PR DESCRIPTION
允许组内管理员/组长进行设置新的管理员，用于换届信息更新。#1

preview:
![image](https://user-images.githubusercontent.com/40660121/86470963-0d470880-bd6f-11ea-9423-4b5a50fbc037.png)

PS:
暂时不支持删除管理员

顺手还改了一下首页的招新顺序（讲道理其实应该在后端改的...