### PR TITLE
fix: should not remove comment when click

### DIFF
--- a/src/components/Comments/index.tsx
+++ b/src/components/Comments/index.tsx
@@ -61,7 +61,6 @@ const Comments: FC<Props> = memo(
         };
 
         const handleCopy = (comment: Comment) => () => {
-            remove(cid, comment._id);
             setEvaluation(comment.evaluation);
             setContent(comment.content);
         };


### PR DESCRIPTION
This is a really confusing behavior. When clicking a comment, it should not be removed.