### PR TITLE
fix: chrome date

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -118,7 +118,7 @@ const CandidateCard: FC<Props> = memo((props) => {
             </Typography>
             {allocation && isTeamInterview && (
                 <Typography color='textSecondary' variant='caption' display='block'>
-                    {new Date(allocation).toLocaleString('zh-CN', { hour12: false })}
+                    {new Date(allocation).toLocaleString('ja-JP', { hour12: false })}
                 </Typography>
             )}
         </span>

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -90,7 +90,7 @@ const CandidateTable: FC<Props> = memo(({ candidates, changeType, interviewType,
                             {candidates.map(({ rejected, abandon, name, group, _id, interviews }) => {
                                 const { selection, allocation } = interviews[interviewType];
                                 const slotInfo = allocation
-                                    ? new Date(allocation).toLocaleString('zh-CN', { hour12: false })
+                                    ? new Date(allocation).toLocaleString('ja-JP', { hour12: false })
                                     : '未分配';
                                 const state = (
                                     <>


### PR DESCRIPTION
We can temporarily fallback to `ja-JP`.
This issue is tested in Chrome 89 / Safari 14.0.3

<img width="401" alt="Screen Shot 2021-03-19 at 18 43 20" src="https://user-images.githubusercontent.com/9049783/111768506-fb989780-88e2-11eb-8603-d9fbff5a2221.png">

<img width="386" alt="Screen Shot 2021-03-19 at 18 43 43" src="https://user-images.githubusercontent.com/9049783/111768557-09e6b380-88e3-11eb-9c33-b5502591584a.png">


Current:
<img width="158" alt="Screen Shot 2021-03-19 at 18 43 52" src="https://user-images.githubusercontent.com/9049783/111768576-10752b00-88e3-11eb-8d49-1be1be0227bd.png">
