### PR TITLE
fix(candidate): always fetch data

### DIFF
--- a/src/epics/candidate/getCandidates.ts
+++ b/src/epics/candidate/getCandidates.ts
@@ -1,7 +1,7 @@
 import { ofType } from 'redux-observable';
-import { of } from 'rxjs';
+import { merge, of } from 'rxjs';
 import { ajax } from 'rxjs/ajax';
-import { catchError, mergeMap, startWith } from 'rxjs/operators';
+import { catchError, filter, map, mergeMap, startWith } from 'rxjs/operators';
 
 import {
     enqueueSnackbar,
@@ -18,29 +18,33 @@ import { Candidate } from '../../config/types';
 
 import { checkToken, customError, Epic, errHandler } from '../';
 
-export const getCandidatesEpic: Epic<GetCandidatesStart> = (action$, state$, { localStorage }) =>
-    action$.pipe(
-        ofType(GET_CANDIDATES_START),
-        mergeMap((action) => {
-            const token = checkToken();
-            const { title, step, group } = action;
-            const candidates = localStorage.getItem('candidates');
-            const viewing = localStorage.getItem('viewing');
-            if (candidates && title === viewing) {
-                let data = candidates;
-                if (step) data = data.filter((candidate: Candidate) => candidate.step === step);
-                if (group) data = data.filter((candidate: Candidate) => candidate.group === group);
-                return of(
-                    getCandidatesFulfilled(data),
-                    toggleFabOff(),
-                    enqueueSnackbar('成功获取候选人信息', { variant: 'success' }),
-                );
-            }
-            return ajax
+export const getCandidatesEpic: Epic<GetCandidatesStart> = (action$, state$, { localStorage }) => {
+    const start$ = action$.pipe(ofType(GET_CANDIDATES_START));
+    const fromCache$ = start$.pipe(
+        map((action) => ({
+            ...action,
+            candidates: localStorage.getItem('candidates'),
+            viewing: localStorage.getItem('viewing'),
+        })),
+        filter(({ candidates, viewing, title }) => candidates !== null && title === viewing),
+        mergeMap(({ step, group, candidates }) => {
+            let data = candidates!;
+            if (step) data = data.filter((candidate) => candidate.step === step);
+            if (group) data = data.filter((candidate) => candidate.group === group);
+            return of(
+                getCandidatesFulfilled(data),
+                toggleFabOff(),
+                enqueueSnackbar('成功获取候选人信息（缓存）', { variant: 'success' }),
+            );
+        }),
+    );
+    const fromAjax$ = start$.pipe(
+        mergeMap(({ title, step, group }) =>
+            ajax
                 .getJSON<{ type: string; data: Candidate[] }>(
                     `${API}/candidate/${JSON.stringify({ title, step, group })}`,
                     {
-                        Authorization: `Bearer ${token}`,
+                        Authorization: `Bearer ${checkToken()}`,
                     },
                 )
                 .pipe(
@@ -50,7 +54,7 @@ export const getCandidatesEpic: Epic<GetCandidatesStart> = (action$, state$, { l
                                 getCandidatesFulfilled(res.data),
                                 setViewingRecruitmentFulfilled(title),
                                 toggleFabOff(),
-                                enqueueSnackbar('成功获取候选人信息', { variant: 'success' }),
+                                enqueueSnackbar('成功获取候选人信息（线上）', { variant: 'success' }),
                                 toggleProgress(),
                             );
                         }
@@ -58,7 +62,8 @@ export const getCandidatesEpic: Epic<GetCandidatesStart> = (action$, state$, { l
                     }),
                     startWith(toggleProgress(true)),
                     catchError((err) => errHandler(err)),
-                );
-        }),
-        catchError((err) => errHandler(err)),
+                ),
+        ),
     );
+    return merge(fromCache$, fromAjax$);
+};


### PR DESCRIPTION
## Code
No additional  `Action`, no Fetch API inside RxJS pipeline. Just a more Rx approach :)

```typescript
export const getCandidatesEpic: Epic<GetCandidatesStart> = (action$, state$, { localStorage }) => {
    const start$ = action$.pipe(ofType(GET_CANDIDATES_START));
    const fromCache$ = start$.pipe(...);
    const fromAjax$ = start$.pipe(...);
    return merge(fromCache$, fromAjax$);
}
```

## Todo
Can we just move `fromCache$` into initialization of redux store? It's a f***ing mystery to me that we always read `localStorage`!

